### PR TITLE
fix: Vite Build Import Warning

### DIFF
--- a/resources/js/ssr.js
+++ b/resources/js/ssr.js
@@ -12,7 +12,7 @@ createServer((page) =>
     page,
     render: renderToString,
     title: (title) => `${title} - ${appName}`,
-    resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
+    resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('/Pages/**/*.vue')),
     setup({ App, props, plugin }) {
       return createSSRApp({ render: () => h(App, props) })
         .use(plugin)


### PR DESCRIPTION
Fixes `"ssrRenderDynamicModel" is imported from external module "vue/server-renderer" but never used` warning.