### PR TITLE
feat: Password Max Length Rule

### DIFF
--- a/app/Http/Requests/Auth/PasswordUpdateForgottenRequest.php
+++ b/app/Http/Requests/Auth/PasswordUpdateForgottenRequest.php
@@ -16,7 +16,7 @@ final class PasswordUpdateForgottenRequest extends FormRequest implements Reques
     {
         return [
             'email' => ['required', 'string', 'email', 'max:255'],
-            'password' => ['required', 'string', 'min:14', 'confirmed'],
+            'password' => ['required', 'string', 'min:14', 'max:255', 'confirmed'],
             'token' => ['required', 'string'],
         ];
     }

--- a/app/Http/Requests/Auth/PasswordUpdateRequest.php
+++ b/app/Http/Requests/Auth/PasswordUpdateRequest.php
@@ -16,7 +16,7 @@ final class PasswordUpdateRequest extends FormRequest implements RequestInterfac
     {
         return [
             'current_password' => ['required', 'string', 'current_password'],
-            'password' => ['required', 'string', 'min:14', 'confirmed'],
+            'password' => ['required', 'string', 'min:14', 'max:255', 'confirmed'],
         ];
     }
 }

--- a/app/Http/Requests/Auth/ProfileStoreRequest.php
+++ b/app/Http/Requests/Auth/ProfileStoreRequest.php
@@ -18,7 +18,7 @@ final class ProfileStoreRequest extends FormRequest implements RequestInterface
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
-            'password' => ['required', 'string', 'min:14', 'confirmed'],
+            'password' => ['required', 'string', 'min:14', 'max:255', 'confirmed'],
         ];
     }
 }

--- a/tests/Datasets/PasswordArraysUpdateInvalid.php
+++ b/tests/Datasets/PasswordArraysUpdateInvalid.php
@@ -27,6 +27,16 @@ dataset('password-arrays-update-invalid', function () use ($standard_array) {
             array_merge($standard_array, ['password' => 'password', 'password_confirmation' => 'password']),
             ['password' => 'The password field must be at least 14 characters.'],
         ],
+        'password >255 characters' => [
+            array_merge(
+                $standard_array,
+                [
+                    'password' => str_pad('', 256, 'a'),
+                    'password_confirmation' => str_pad('', 256, 'a'),
+                ],
+            ),
+            ['password' => 'The password field must not be greater than 255 characters.'],
+        ],
         'password confirmation missing' => [
             ['password' => 'ten4characters'],
             ['password' => 'The password field confirmation does not match.'],

--- a/tests/Datasets/ProfileArraysStoreInvalid.php
+++ b/tests/Datasets/ProfileArraysStoreInvalid.php
@@ -85,6 +85,16 @@ dataset('profile-arrays-store-invalid', function () use ($standard_array) {
             array_merge($standard_array, ['password' => 'password', 'password_confirmation' => 'password']),
             ['password' => 'The password field must be at least 14 characters.'],
         ],
+        'password >255 characters' => [
+            array_merge(
+                $standard_array,
+                [
+                    'password' => str_pad('', 256, 'a'),
+                    'password_confirmation' => str_pad('', 256, 'a'),
+                ],
+            ),
+            ['password' => 'The password field must not be greater than 255 characters.'],
+        ],
         'password confirmation missing' => [
             [
                 'name' => 'Test User',

--- a/tests/Unit/App/Http/Requests/Admin/PageUpdateRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Admin/PageUpdateRequestTest.php
@@ -16,7 +16,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'title' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/LoginRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/LoginRequestTest.php
@@ -20,7 +20,7 @@ test('authorize returns ok', function () {
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'email' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/LoginRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/LoginRequestTest.php
@@ -25,6 +25,7 @@ test('rules returns ok', function () {
             'required',
             'string',
             'email',
+            'max:255',
         ],
         'password' => [
             'required',

--- a/tests/Unit/App/Http/Requests/Auth/PasswordResetLinkRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/PasswordResetLinkRequestTest.php
@@ -18,7 +18,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'email' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/PasswordUpdateForgottenRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/PasswordUpdateForgottenRequestTest.php
@@ -18,7 +18,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'email' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/PasswordUpdateForgottenRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/PasswordUpdateForgottenRequestTest.php
@@ -29,6 +29,7 @@ test('rules returns ok', function () {
             'required',
             'string',
             'min:14',
+            'max:255',
             'confirmed',
         ],
         'token' => [

--- a/tests/Unit/App/Http/Requests/Auth/PasswordUpdateRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/PasswordUpdateRequestTest.php
@@ -28,6 +28,7 @@ test('rules returns ok', function () {
             'required',
             'string',
             'min:14',
+            'max:255',
             'confirmed',
         ],
     ], $actual);

--- a/tests/Unit/App/Http/Requests/Auth/PasswordUpdateRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/PasswordUpdateRequestTest.php
@@ -18,7 +18,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'current_password' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/ProfileDeleteRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/ProfileDeleteRequestTest.php
@@ -18,7 +18,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'password' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/ProfileStoreRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/ProfileStoreRequestTest.php
@@ -36,6 +36,7 @@ test('rules returns ok', function () {
             'required',
             'string',
             'min:14',
+            'max:255',
             'confirmed',
         ],
     ], $actual);

--- a/tests/Unit/App/Http/Requests/Auth/ProfileStoreRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/ProfileStoreRequestTest.php
@@ -18,7 +18,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'name' => [
             'required',
             'string',

--- a/tests/Unit/App/Http/Requests/Auth/ProfileUpdateRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Auth/ProfileUpdateRequestTest.php
@@ -19,7 +19,7 @@ arch('it implements the expected interface')
 test('rules returns ok', function () {
     $actual = $this->subject->rules();
 
-    $this->assertValidationRules([
+    $this->assertExactValidationRules([
         'name' => [
             'required',
             'string',


### PR DESCRIPTION
Also updates request class `rules` method unit tests to use `assertExactValidationRules` instead of `assertValidationRules`.