### PR TITLE
chore: Move BlockType Enum

### DIFF
--- a/app/Enums/Blocks/BlockType.php
+++ b/app/Enums/Blocks/BlockType.php
@@ -4,6 +4,7 @@ namespace App\Enums\Blocks;
 
 enum BlockType: string
 {
+    /* List of the content blocks available to the application. */
     case STACK = 'stack';
     case TABS = 'tabs';
 }

--- a/app/Enums/Blocks/BlockType.php
+++ b/app/Enums/Blocks/BlockType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Enums;
+namespace App\Enums\Blocks;
 
 enum BlockType: string
 {

--- a/app/Http/Resources/Views/Blocks/BlocksResource.php
+++ b/app/Http/Resources/Views/Blocks/BlocksResource.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Resources\Views\Blocks;
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Interfaces\Resources\Indexes\CollectionIndexInterface;
 use App\Models\Block;
 use Illuminate\Support\Collection;

--- a/app/Http/Resources/Views/Blocks/StackBlockResource.php
+++ b/app/Http/Resources/Views/Blocks/StackBlockResource.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Resources\Views\Blocks;
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Http\Resources\Formatters\LaravelVersionFormatterResource;
 use App\Http\Resources\Formatters\PhpVersionFormatterResource;
 use App\Interfaces\Resources\Items\ConstantItemInterface;

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/database/factories/BlockFactory.php
+++ b/database/factories/BlockFactory.php
@@ -2,7 +2,7 @@
 
 namespace Database\Factories;
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Models\Block;
 use App\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/storage/app/seeds/pages.php
+++ b/storage/app/seeds/pages.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Enums\Webpages\WebpageTemplate;
 
 /*

--- a/tests/Datasets/BlockTypes.php
+++ b/tests/Datasets/BlockTypes.php
@@ -1,5 +1,5 @@
 <?php
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 
 dataset('block-types', fn () => BlockType::cases());

--- a/tests/Datasets/Blocks.php
+++ b/tests/Datasets/Blocks.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Http\Resources\Formatters\LaravelVersionFormatterResource;
 use App\Http\Resources\Formatters\PhpVersionFormatterResource;
 use App\Models\Block;

--- a/tests/Unit/App/Enums/EnumsArchitectureTest.php
+++ b/tests/Unit/App/Enums/EnumsArchitectureTest.php
@@ -6,6 +6,10 @@ arch('app/Enums has valid architecture')
     ->not->toHaveSuffix('Enum')
     ->toBeUsedIn('App');
 
+test('app/Enums/Blocks has valid architecture')
+    ->expect('App\Enums\Blocks')
+    ->toHavePrefix('Block');
+
 test('app/Enums/Webpages has valid architecture')
     ->expect('App\Enums\Webpages')
     ->toHavePrefix('Webpage');

--- a/tests/Unit/App/Http/Resources/Views/Blocks/StackBlockResourceTest.php
+++ b/tests/Unit/App/Http/Resources/Views/Blocks/StackBlockResourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Http\Resources\Views\Blocks\StackBlockResource;
 use App\Interfaces\Resources\Items\ConstantItemInterface;
 

--- a/tests/Unit/Database/Factories/BlockFactoryTest.php
+++ b/tests/Unit/Database/Factories/BlockFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Enums\BlockType;
+use App\Enums\Blocks\BlockType;
 use App\Models\Block;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 


### PR DESCRIPTION
Moves `BlockType` enum to new `Blocks` namespace with an architecture test for the new namespace.