### PR TITLE
chore: Remove Redundant Arch Tests

### DIFF
--- a/tests/Unit/App/Interfaces/Resources/Indexes/CollectionIndexInterfaceTest.php
+++ b/tests/Unit/App/Interfaces/Resources/Indexes/CollectionIndexInterfaceTest.php
@@ -1,7 +1,0 @@
-<?php
-
-use App\Interfaces\Resources\Indexes\CollectionIndexInterface;
-
-arch('it has a getItems method')
-    ->expect(CollectionIndexInterface::class)
-    ->toHaveMethod('getItems');

--- a/tests/Unit/App/Interfaces/Resources/items/ConstantItemInterfaceTest.php
+++ b/tests/Unit/App/Interfaces/Resources/items/ConstantItemInterfaceTest.php
@@ -1,7 +1,0 @@
-<?php
-
-use App\Interfaces\Resources\Items\ConstantItemInterface;
-
-arch('it has a getItem method')
-    ->expect(ConstantItemInterface::class)
-    ->toHaveMethod('getItem');


### PR DESCRIPTION
Assertions are already covered in `HttpArchitectureTest`