### PR TITLE
feat: Create WebpageStatus Enum

### DIFF
--- a/app/Enums/Webpages/WebpageStatus.php
+++ b/app/Enums/Webpages/WebpageStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums\Webpages;
+
+enum WebpageStatus: int
+{
+    /* List of the webpage statuses available to the application. */
+    case DRAFT = 1;
+    case PUBLISHED = 2;
+
+    /** Get the status's label. */
+    public function label(): string
+    {
+        return match ($this) {
+            self::DRAFT => 'Draft',
+            self::PUBLISHED => 'Published',
+        };
+    }
+}

--- a/app/Http/Controllers/Public/PageController.php
+++ b/app/Http/Controllers/Public/PageController.php
@@ -27,9 +27,10 @@ final class PageController extends Controller
             return to_route('home');
         }
 
-        $template = WebpageTemplate::tryFrom($page?->template ?? '');
-
-        if (!$template) {
+        if (
+            !$page->isPublished()
+            || !$template = WebpageTemplate::tryFrom($page?->template ?? '')
+        ) {
             abort(404);
         }
 

--- a/app/Http/Requests/Admin/PageUpdateRequest.php
+++ b/app/Http/Requests/Admin/PageUpdateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Enums\Webpages\WebpageStatus;
 use App\Interfaces\Requests\RequestInterface;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -18,6 +19,7 @@ final class PageUpdateRequest extends FormRequest implements RequestInterface
             'blocks' => ['nullable', 'max:5120'],
             'title' => ['required', 'string', 'max:255'],
             'metaDescription' => ['nullable', 'string', 'max:255'],
+            'webpageStatusId' => ['required', 'integer', 'max:' . WebpageStatus::PUBLISHED->value],
             'inSitemap' => ['required', 'boolean'],
         ];
     }

--- a/app/Http/Resources/Views/Admin/Pages/CreateEditPageResource.php
+++ b/app/Http/Resources/Views/Admin/Pages/CreateEditPageResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Views\Admin\Pages;
 
+use App\Enums\Webpages\WebpageStatus;
 use App\Http\Resources\Views\Admin\Blocks\AdminBlocksResource;
 use App\Interfaces\Resources\Items\PageItemInterface;
 use App\Models\Page;
@@ -22,6 +23,7 @@ final class CreateEditPageResource implements PageItemInterface
      *  title: string,
      *  metaDescription: string,
      *  inSitemap: bool,
+     *  webpageStatusId: int,
      * }
      */
     public function getItem(Page $page): array
@@ -32,6 +34,7 @@ final class CreateEditPageResource implements PageItemInterface
             'title' => $page->getTitle(),
             'metaDescription' => $page->getMetaDescription(),
             'inSitemap' => $page->isInSitemap(),
+            'webpageStatusId' => WebpageStatus::tryFrom($page->webpage_status_id ?? 1)?->value ?? WebpageStatus::DRAFT->value,
         ];
     }
 }

--- a/app/Http/Resources/Views/Public/Content/HomepageContentResource.php
+++ b/app/Http/Resources/Views/Public/Content/HomepageContentResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources\Views\Public\Content;
 
 use App\Enums\Blocks\BlockType;
+use App\Enums\Webpages\WebpageStatus;
 use App\Enums\Webpages\WebpageTemplate;
 use App\Interfaces\Resources\Items\ConstantItemInterface;
 use App\Models\Block;
@@ -17,6 +18,7 @@ final class HomepageContentResource implements ConstantItemInterface
         if (!$this->page->id) {
             $this->page = Page::query()
                 ->isHomepage()
+                ->published()
                 ->with('blocks')
                 ->first()
                 ?? new Page;
@@ -52,6 +54,7 @@ final class HomepageContentResource implements ConstantItemInterface
     public function setDefaultModel(): void
     {
         $this->page = new Page([
+            'webpage_status_id' => WebpageStatus::PUBLISHED->value,
             'template' => WebpageTemplate::PUBLIC_CONTENT->value,
             'slug' => 'home',
             'title' => config('app.name'),

--- a/app/Http/Resources/Views/Public/Content/PrivacyPolicyContentResource.php
+++ b/app/Http/Resources/Views/Public/Content/PrivacyPolicyContentResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources\Views\Public\Content;
 
 use App\Enums\Blocks\BlockType;
+use App\Enums\Webpages\WebpageStatus;
 use App\Enums\Webpages\WebpageTemplate;
 use App\Http\Resources\Views\Public\Metadata\PageMetadataResource;
 use App\Interfaces\Resources\Items\ConstantItemInterface;
@@ -17,6 +18,7 @@ final class PrivacyPolicyContentResource implements ConstantItemInterface
     ) {
         if (!$this->page->id) {
             $this->page = Page::query()
+                ->published()
                 ->where('slug', 'privacy')
                 ->with('blocks')
                 ->first()
@@ -63,6 +65,7 @@ final class PrivacyPolicyContentResource implements ConstantItemInterface
     public function setDefaultModel(): void
     {
         $this->page = new Page([
+            'webpage_status_id' => WebpageStatus::PUBLISHED->value,
             'template' => WebpageTemplate::PUBLIC_CONTENT->value,
             'slug' => 'privacy',
             'title' => 'Privacy Policy',

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -28,6 +28,7 @@ final class Page extends Model
      * @var array<int, string>
      */
     protected $fillable = [
+        'webpage_status_id',
         'slug',
         'title',
         'meta_description',

--- a/app/Traits/HasPageView.php
+++ b/app/Traits/HasPageView.php
@@ -2,11 +2,13 @@
 
 namespace App\Traits;
 
+use App\Enums\Webpages\WebpageStatus;
 use App\Enums\Webpages\WebpageTemplate;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
+ * @method Builder|static published()
  * @method Builder|static inSitemap()
  * @method static Builder|static query()
  */
@@ -49,6 +51,14 @@ trait HasPageView
     {
         return $query->where(function ($query) {
             $query->where('in_sitemap', 1);
+        });
+    }
+
+    /** Returns all models that are Published (webpage_status_id = 2). */
+    public function scopePublished(Builder|QueryBuilder $query): Builder|QueryBuilder
+    {
+        return $query->where(function ($query) {
+            $query->where('webpage_status_id', WebpageStatus::PUBLISHED->value);
         });
     }
 }

--- a/app/Traits/HasPageView.php
+++ b/app/Traits/HasPageView.php
@@ -46,6 +46,12 @@ trait HasPageView
         return $this->in_sitemap ?? false;
     }
 
+    /** Returns true if the item is marked as published. */
+    public function isPublished(): bool
+    {
+        return $this->webpage_status_id === WebpageStatus::PUBLISHED->value;
+    }
+
     /** Returns all models that should be in the sitemap (in_sitemap = 1). */
     public function scopeInSitemap(Builder|QueryBuilder $query): Builder|QueryBuilder
     {

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -48,6 +48,15 @@ final class PageFactory extends Factory
         ]));
     }
 
+    /** Indicate that the model should have draft webpage status. */
+    public function draft(): static
+    {
+        return $this->state(fn (array $attributes) => array_merge([
+            ...$attributes,
+            'webpage_status_id' => WebpageStatus::DRAFT->value,
+        ]));
+    }
+
     /** Indicate that the model should use faked data with all fields filled. */
     public function dummy(): static
     {

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Enums\Blocks\BlockType;
+use App\Enums\Webpages\WebpageStatus;
 use App\Enums\Webpages\WebpageTemplate;
 use App\Traits\FakesDatabaseValues;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -17,13 +18,14 @@ final class PageFactory extends Factory
     /**
      * Define the model's default state.
      *
-     * @return array<string, bool|string|null>
+     * @return array<string, bool|int|string|null>
      */
     public function definition(): array
     {
         $title = $this->getFakeString();
 
         return [
+            'webpage_status_id' => WebpageStatus::PUBLISHED->value,
             'slug' => urlencode(str_replace(' ', '-', $title)),
             'title' => ucwords($title),
             'meta_description' => null,

--- a/database/migrations/2024_07_16_000001_add_webpage_status_id_to_pages.php
+++ b/database/migrations/2024_07_16_000001_add_webpage_status_id_to_pages.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /** Run the migrations. */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('pages', 'webpage_status_id')) {
+            Schema::table('pages', function (Blueprint $table) {
+                $table->integer('webpage_status_id')->nullable()->after('id');
+            });
+        }
+    }
+
+    /** Reverse the migrations. */
+    public function down(): void
+    {
+        if (Schema::hasColumn('pages', 'webpage_status_id')) {
+            Schema::table('pages', function (Blueprint $table) {
+                $table->dropColumn('webpage_status_id');
+            });
+        }
+    }
+};

--- a/database/seeders/PageSeeder.php
+++ b/database/seeders/PageSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\Webpages\WebpageStatus;
 use App\Enums\Webpages\WebpageTemplate;
 use App\Models\Block;
 use App\Models\Page;
@@ -27,6 +28,7 @@ final class PageSeeder extends Seeder
         if ($seeds !== [0]) {
             foreach ($seeds as $seed) {
                 $page = Page::factory()->create([
+                    'webpage_status_id' => $seed['webpage_status_id'] ?? WebpageStatus::PUBLISHED->value,
                     'slug' => $seed['slug'] ?? null,
                     'title' => $seed['title'] ?? null,
                     'in_sitemap' => $seed['in_sitemap'] ?? 1,

--- a/resources/js/Pages/Admin/Partials/CreateEditPage.vue
+++ b/resources/js/Pages/Admin/Partials/CreateEditPage.vue
@@ -3,6 +3,7 @@ import AppForm from '@/Components/Forms/AppForm.vue'
 import FormInput from '@/Components/Forms/FormInput.vue'
 import InputBlocks from '@/Components/Forms/Inputs/InputBlocks.vue'
 import InputCheckbox from '@/Components/Forms/Inputs/InputCheckbox.vue'
+import InputSelect from '@/Components/Forms/Inputs/InputSelect.vue'
 import InputText from '@/Components/Forms/Inputs/InputText.vue'
 import AppSectionDivider from '@/Components/Sections/AppSectionDivider.vue'
 import TabBody from '@/Components/Controls/Tabs/TabBody.vue'
@@ -17,6 +18,7 @@ const form = useForm({
   inSitemap: page.inSitemap,
   metaDescription: page.metaDescription,
   title: page.title,
+  webpageStatusId: page.webpageStatusId,
 })
 
 </script>
@@ -90,6 +92,28 @@ const form = useForm({
             type="text"
             class="block w-full"
             v-model="form.metaDescription"
+          />
+        </FormInput>
+      </div>
+
+      <div class="w-full flex pt-2 px-4">
+        <FormInput
+          input-label="Webpage Status"
+          input-label-position="left"
+          input-field="webpageStatusId"
+          :parent-form="form"
+        >
+          <InputSelect
+            id="input-webpage-status-id"
+            name="webpageStatusId"
+            class="block w-full"
+            v-model="form.webpageStatusId"
+            :class="{ 'opacity-25': form.processing }"
+            :disabled="form.processing"
+            :options="{
+              0: { label: 'Draft', value: 1 },
+              1: { label: 'Published', value: 2 },
+            }"
           />
         </FormInput>
       </div>

--- a/tests/Datasets/PageArraysUpdateInvalid.php
+++ b/tests/Datasets/PageArraysUpdateInvalid.php
@@ -2,6 +2,7 @@
 
 $standard_array = [
     'title' => 'Title',
+    'webpageStatusId' => 1,
     'inSitemap' => true,
 ];
 
@@ -11,11 +12,12 @@ dataset('page-arrays-update-invalid', function () use ($standard_array) {
             [],
             [
                 'title' => 'The title field is required.',
+                'webpageStatusId' => 'The webpage status id field is required.',
                 'inSitemap' => 'The in sitemap field is required.',
             ],
         ],
         'title missing' => [
-            ['inSitemap' => true],
+            ['webpageStatusId' => 1, 'inSitemap' => true],
             ['title' => 'The title field is required.'],
         ],
         'title empty' => [
@@ -38,8 +40,24 @@ dataset('page-arrays-update-invalid', function () use ($standard_array) {
             array_merge($standard_array, ['metaDescription' => str_pad('', 256, 'a')]),
             ['metaDescription' => 'The meta description field must not be greater than 255 characters.'],
         ],
+        'webpageStatusId missing' => [
+            ['title' => 'Title', 'inSitemap' => true],
+            ['webpageStatusId' => 'The webpage status id field is required.'],
+        ],
+        'webpageStatusId empty' => [
+            array_merge($standard_array, ['webpageStatusId' => '']),
+            ['webpageStatusId' => 'The webpage status id field is required.'],
+        ],
+        'webpageStatusId not integer' => [
+            array_merge($standard_array, ['webpageStatusId' => 'a']),
+            ['webpageStatusId' => 'The webpage status id field must be an integer.'],
+        ],
+        'webpageStatusId > max WebpageStatus' => [
+            array_merge($standard_array, ['webpageStatusId' => 42]),
+            ['webpageStatusId' => 'The webpage status id field must not be greater than 2.'],
+        ],
         'inSitemap missing' => [
-            ['title' => 'Title'],
+            ['title' => 'Title', 'webpageStatusId' => 1],
             ['inSitemap' => 'The in sitemap field is required.'],
         ],
         'inSitemap empty' => [

--- a/tests/Datasets/PageGhosts.php
+++ b/tests/Datasets/PageGhosts.php
@@ -7,6 +7,7 @@ dataset('page-ghosts', function () {
         'new model' => [fn () => new Page],
         'page ghost min record' => [fn () => Page::factory()->make()],
         'page ghost max random record' => [fn () => Page::factory()->dummy()->make()],
+        'page ghost draft' => [fn () => Page::factory()->draft()->make()],
         'homepage ghost' => [fn () => Page::factory()->dummy()->homePage()->make()],
         'privacy page ghost' => [fn () => Page::factory()->dummy()->privacyPage()->make()],
     ];

--- a/tests/Datasets/Pages.php
+++ b/tests/Datasets/Pages.php
@@ -30,6 +30,7 @@ dataset('pages', function () use ($pages_with_blocks) {
     return [
         'page min record' => [fn () => Page::factory()->create()],
         'page max random record' => [fn () => Page::factory()->dummy()->create()],
+        'page draft' => [fn () => Page::factory()->draft()->create()],
         'homepage' => [fn () => Page::factory()->homePage()->create()],
         'about page' => [fn () => Page::factory()->aboutPage()->create()],
         'privacy page' => [fn () => Page::factory()->privacyPage()->create()],

--- a/tests/Feature/Http/Controllers/Admin/PageControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/PageControllerTest.php
@@ -71,6 +71,7 @@ test('update returns correctly for minimum valid data', function (Page $page) {
     $user = User::factory()->isAdmin()->create();
     $data = [
         'title' => $page->getTitle() . ' - UPDATED',
+        'webpageStatusId' => $page->webpage_status_id,
         'inSitemap' => (bool) $page->in_sitemap,
     ];
 
@@ -88,6 +89,7 @@ test('update returns correctly for minimum valid data', function (Page $page) {
 
     expect($page->title)->toEqual($data['title']);
     expect($page->meta_description)->toEqual($page_original->meta_description);
+    expect($page->webpage_status_id)->toEqual($page_original->webpage_status_id);
     expect($page->in_sitemap)->toEqual($page_original->in_sitemap);
     expect($page->blocks)->toEqual($page_original->blocks);
 })->with('pages');
@@ -99,6 +101,7 @@ test('update returns correctly for maximum valid data', function (Page $page) {
     $data = [
         'title' => 'New Title',
         'metaDescription' => 'New Meta-Description',
+        'webpageStatusId' => $page->webpage_status_id !== 1 ? 1 : 2,
         'inSitemap' => !$page->in_sitemap,
     ];
 
@@ -116,6 +119,7 @@ test('update returns correctly for maximum valid data', function (Page $page) {
 
     expect($page->title)->toEqual($data['title']);
     expect($page->meta_description)->toEqual($data['metaDescription']);
+    expect($page->webpage_status_id)->toEqual($data['webpageStatusId']);
     expect($page->in_sitemap)->toEqual($data['inSitemap']);
     expect($page->blocks)->toEqual($page_original->blocks);
 })->with('pages');
@@ -127,6 +131,7 @@ test('update ignores unknown fields', function () {
     $user = User::factory()->isAdmin()->create();
     $data = [
         'title' => $page->getTitle() . ' - UPDATED',
+        'webpageStatusId' => $page->webpage_status_id,
         'inSitemap' => (bool) $page->in_sitemap,
         'unknownField' => 'invalid value',
     ];
@@ -147,6 +152,7 @@ test('update ignores unknown fields', function () {
     expect($page->unknown_field)->toBeNull();
     expect($page->title)->toEqual($data['title']);
     expect($page->meta_description)->toEqual($page_original->meta_description);
+    expect($page->webpage_status_id)->toEqual($page_original->webpage_status_id);
     expect($page->in_sitemap)->toEqual($page_original->in_sitemap);
     expect($page->blocks)->toEqual($page_original->blocks);
 });

--- a/tests/Feature/Http/Controllers/Public/PageControllerTest.php
+++ b/tests/Feature/Http/Controllers/Public/PageControllerTest.php
@@ -16,7 +16,15 @@ test('show renders the page view', function (Page $page) {
     $actual = $this->get($route);
     $session = session()->all();
     $headers = $actual->headers->all();
-    $status = $page->is_homepage ? 302 : 200;
+    $status = 200;
+
+    if (!$page->isPublished()) {
+        $status = 404;
+    }
+
+    if ($page->is_homepage) {
+        $status = 302;
+    }
 
     $actual
         ->assertStatus($status)

--- a/tests/Unit/App/Http/Requests/Admin/PageUpdateRequestTest.php
+++ b/tests/Unit/App/Http/Requests/Admin/PageUpdateRequestTest.php
@@ -35,5 +35,10 @@ test('rules returns ok', function () {
             'required',
             'boolean',
         ],
+        'webpageStatusId' => [
+            'required',
+            'integer',
+            'max:2',
+        ],
     ], $actual);
 });

--- a/tests/Unit/App/Http/Resources/Views/Admin/Pages/CreateEditPageResourceTest.php
+++ b/tests/Unit/App/Http/Resources/Views/Admin/Pages/CreateEditPageResourceTest.php
@@ -17,12 +17,14 @@ test('getItem returns ok with stored models', function (Page $page) {
 
     expect($actual)
         ->toHaveCamelCaseKeys()
+        ->toHaveCount(6)
         ->toMatchArray([
             'id' => $page->id,
             'blocks' => (new AdminBlocksResource($page->blocks, $page))->getItems(),
             'title' => $page->getTitle(),
             'metaDescription' => $page->getMetaDescription(),
             'inSitemap' => $page->isInSitemap(),
+            'webpageStatusId' => $page->isPublished() ? 2 : 1,
         ]);
 })->with('pages');
 
@@ -31,11 +33,13 @@ test('getItem returns ok with ghost models', function (Page $page) {
 
     expect($actual)
         ->toHaveCamelCaseKeys()
+        ->toHaveCount(6)
         ->toMatchArray([
             'id' => $page->id,
             'blocks' => (new AdminBlocksResource($page->blocks, $page))->getItems(),
             'title' => $page->getTitle(),
             'metaDescription' => $page->getMetaDescription(),
             'inSitemap' => $page->isInSitemap(),
+            'webpageStatusId' => $page->isPublished() ? 2 : 1,
         ]);
 })->with('page-ghosts');

--- a/tests/Unit/App/Services/Admin/PageAdminServiceTest.php
+++ b/tests/Unit/App/Services/Admin/PageAdminServiceTest.php
@@ -26,6 +26,7 @@ test('update returns correctly for minimum valid data', function (Page $page) {
         ->title->toEqual($data['title'])
         ->meta_description->toEqual($page_original->meta_description)
         ->in_sitemap->toEqual($page_original->in_sitemap)
+        ->webpage_status_id->toEqual($page_original->webpage_status_id)
         ->template->toEqual($page_original->template)
         ->blocks->toEqual($page_original->blocks);
 })->with('pages');
@@ -45,6 +46,7 @@ test('update returns correctly for maximum valid data', function (Page $page) {
     }
 
     $data = [
+        'webpageStatusId' => $page->webpage_status_id === 1 ? 2 : 1,
         'title' => 'New Title',
         'metaDescription' => 'New Meta-Description',
         'inSitemap' => !$page->in_sitemap,
@@ -62,6 +64,7 @@ test('update returns correctly for maximum valid data', function (Page $page) {
         ->title->toEqual($data['title'])
         ->meta_description->toEqual($data['metaDescription'])
         ->in_sitemap->toEqual($data['inSitemap'])
+        ->webpage_status_id->toEqual($data['webpageStatusId'])
         ->template->toEqual($page_original->template);
 })->with('pages');
 
@@ -88,6 +91,7 @@ test('update ignores unknown fields', function () {
         ->title->toEqual($data['title'])
         ->meta_description->toEqual($page_original->meta_description)
         ->in_sitemap->toEqual($page_original->in_sitemap)
+        ->webpage_status_id->toEqual($page_original->webpage_status_id)
         ->template->toEqual($page_original->template)
         ->blocks->toEqual($page_original->blocks);
 });

--- a/tests/Unit/Database/Factories/PageFactoryTest.php
+++ b/tests/Unit/Database/Factories/PageFactoryTest.php
@@ -27,6 +27,16 @@ it('makes the about page model')
     ->in_sitemap->toBeTrue()
     ->is_homepage->toBeFalse();
 
+it('makes draft page models')
+    ->expect(fn () => Page::factory()->draft()->make())
+    ->title->tobeString()
+    ->slug->toBeString()
+    ->meta_description->toBeNull()
+    ->template->toEqual(WebpageTemplate::PUBLIC_CONTENT->value)
+    ->webpage_status_id->toEqual(WebpageStatus::DRAFT->value)
+    ->in_sitemap->toBeTrue()
+    ->is_homepage->toBeFalse();
+
 it('makes dummy page models')
     ->expect(fn () => Page::factory()->dummy()->make())
     ->title->tobeString()

--- a/tests/Unit/Database/Factories/PageFactoryTest.php
+++ b/tests/Unit/Database/Factories/PageFactoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\Webpages\WebpageStatus;
 use App\Enums\Webpages\WebpageTemplate;
 use App\Models\Page;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,6 +13,7 @@ it('makes page models')
     ->slug->toBeString()
     ->meta_description->toBeNull()
     ->template->toEqual(WebpageTemplate::PUBLIC_CONTENT->value)
+    ->webpage_status_id->toEqual(WebpageStatus::PUBLISHED->value)
     ->in_sitemap->toBeTrue()
     ->is_homepage->toBeFalse();
 
@@ -19,6 +21,7 @@ it('makes the about page model')
     ->expect(fn () => Page::factory()->aboutPage()->make(['title' => 'Test Title']))
     ->title->toEqual('Test Title')
     ->slug->toEqual('about')
+    ->webpage_status_id->toEqual(WebpageStatus::PUBLISHED->value)
     ->meta_description->toBeString()
     ->template->toEqual(WebpageTemplate::PUBLIC_CONTENT->value)
     ->in_sitemap->toBeTrue()
@@ -30,6 +33,7 @@ it('makes dummy page models')
     ->slug->toBeString()
     ->meta_description->toBeString()
     ->template->toEqual(WebpageTemplate::PUBLIC_CONTENT->value)
+    ->webpage_status_id->toEqual(WebpageStatus::PUBLISHED->value)
     ->in_sitemap->toBeTrue()
     ->is_homepage->toBeFalse();
 
@@ -39,6 +43,7 @@ it('makes the homepage page model')
     ->slug->toEqual('home')
     ->meta_description->toBeString()
     ->template->toEqual(WebpageTemplate::PUBLIC_CONTENT->value)
+    ->webpage_status_id->toEqual(WebpageStatus::PUBLISHED->value)
     ->in_sitemap->toBeFalse()
     ->is_homepage->toBeTrue();
 
@@ -48,5 +53,6 @@ it('makes the privacy page model')
     ->slug->toEqual('privacy')
     ->meta_description->toBeString()
     ->template->toEqual(WebpageTemplate::PUBLIC_CONTENT->value)
+    ->webpage_status_id->toEqual(WebpageStatus::PUBLISHED->value)
     ->in_sitemap->toBeTrue()
     ->is_homepage->toBeFalse();


### PR DESCRIPTION
Used to add option to set `Page` models to draft, preventing them being accessed via the public route.