### PR TITLE
fix: Explicitly Set ChromeDriver Port for Dusk

### DIFF
--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -18,7 +18,7 @@ abstract class DuskTestCase extends BaseTestCase
     public static function prepare(): void
     {
         if (!static::runningInSail()) {
-            static::startChromeDriver();
+            static::startChromeDriver(['--port=9515']);
         }
     }
 


### PR DESCRIPTION
Updates `DuskTestCase` to reflect change to related stub from [laravel/dusk commit e641800](https://github.com/laravel/dusk/commit/e641800393ce4ad39f0a47133f51aae67ceb01ad).